### PR TITLE
Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.class
 *.log
+
+.idea/
+target/
+*.jar

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# pac4j-authorizer
-pac4j Authorizer for custom authorization techniques
+# `pac4j-authorizer`
+
+[![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/datagovsg%2Fpac4j-authorizer%2Fpac4j-authorizer?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/pac4j-authorizer/builds?repoOwner=datagovsg&repoName=pac4j-authorizer&serviceName=datagovsg%2Fpac4j-authorizer&filter=trigger:build~Build;branch:master;pipeline:5cfa297b292d363eff05c2dd~pac4j-authorizer)
+
+`pac4j` Authorizer for custom authorization techniques.
+
+This set-up will auto-upload release JAR builds onto GitHub releases
+[here](https://github.com/datagovsg/pac4j-authorizer/releases).
+
+## Credits
+
+Thanks to [@xkjyeah](https://github.com/xkjyeah) for the original code
+contribution!

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,40 @@
+val nameVal = "pac4j-authorizer"
+name := nameVal
+
+val versionVal = "v0.1.0"
+version := versionVal
+
+val scalaVersionVal = "2.11.12"
+
+lazy val testScalafmt = taskKey[Unit]("testScalafmt")
+
+lazy val commonSettings = Seq(
+  version := versionVal,
+  scalaVersion := scalaVersionVal,
+  resolvers += DefaultMavenRepository,
+  libraryDependencies ++= Seq(
+    "io.buji" % "buji-pac4j" % "4.0.0",
+    "org.pac4j" % "pac4j-oauth" % "3.2.0" % "runtime",
+    "org.apache.shiro" % "shiro-web" % "1.4.0",
+    "org.apache.shiro" % "shiro-core" % "1.4.0",
+  ),
+  // Disable parallel test execution to avoid SparkSession conflicts
+  parallelExecution in Test := false
+)
+
+def assemblySettings = Seq(
+  assemblyMergeStrategy in assembly := {
+    case PathList("org", "apache", xs @ _*) => MergeStrategy.last
+    case PathList("META-INF", xs @ _*)      => MergeStrategy.discard
+    case x if x.endsWith("io.netty.versions.properties") =>
+      MergeStrategy.discard
+    case x => MergeStrategy.first
+  },
+  assemblyJarName in assembly := f"${nameVal}-${versionVal}.jar",
+)
+
+lazy val root = (project in file(".")).settings(
+  commonSettings,
+  assemblySettings,
+  libraryDependencies ++= Seq()
+)

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,0 +1,55 @@
+version: '1.0'
+stages:
+- clone
+- test
+- build
+- release
+
+steps:
+  get_github_token:
+    title: Get default GitHub token
+    stage: clone
+    image: codefresh/cli
+    commands:
+    - cf_export GITHUB_TOKEN=$(codefresh get context github --decrypt -o yaml | yq -r .spec.data.auth.password)
+
+  main_clone:
+    title: Clone main repository
+    type: git-clone
+    stage: clone
+    git: github
+    repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
+    revision: ${{CF_REVISION}}
+
+  test:
+    title: Run unit tests
+    stage: test
+    image: hseeberger/scala-sbt:8u181_2.12.8_1.2.8
+    working_directory: ${{main_clone}}
+    commands:
+    - sbt -ivy /codefresh/volume/.ivy2 test
+
+  build_jar:
+    title: Build JAR
+    stage: build
+    image: hseeberger/scala-sbt:8u181_2.12.8_1.2.8
+    working_directory: ${{main_clone}}
+    commands:
+    - rm -f target/scala-2.11/*.jar
+    - sbt -ivy /codefresh/volume/.ivy2 assembly
+
+  upload_jar:
+    title: Upload release JAR
+    stage: release
+    image: guangie88/releaser:alpine_upx-3_ghr-0.12
+    working_directory: ${{main_clone}}
+    commands:
+    - |-
+      if [ -z "${CF_RELEASE_TAG}" ]; then
+        TAG_NAME=experimental
+      else
+        TAG_NAME=${CF_RELEASE_TAG}
+      fi
+    - |-
+      ghr -t ${{GITHUB_TOKEN}} -u ${{CF_REPO_OWNER}} -r ${{CF_REPO_NAME}} \
+          -c ${{CF_REVISION}} -replace ${TAG_NAME} target/scala-2.11/pac4j-authorizer-*.jar

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")

--- a/src/main/scala/p4jauth/EnvDomainAuthorizer.scala
+++ b/src/main/scala/p4jauth/EnvDomainAuthorizer.scala
@@ -1,0 +1,39 @@
+package p4jauth
+
+import org.pac4j.core.authorization.generator.AuthorizationGenerator
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.profile.CommonProfile
+import org.slf4j.LoggerFactory
+
+class EnvDomainAuthorizer extends AuthorizationGenerator[CommonProfile] {
+  // Throw exception when missing AUTHORIZED_DOMAIN for now
+  val authorizedDomain: String = sys.env("AUTHORIZED_DOMAIN")
+
+  val adminUsers =
+    sys.env.getOrElse("ADMIN_USERS", "").split(",").map(_.toLowerCase).toSet
+
+  val logger = LoggerFactory.getLogger(getClass.getName)
+
+  if (adminUsers.isEmpty) {
+    logger.warn(
+      "There are no admin users specified in the environment. You won't be able to administer this service.")
+  }
+
+  private def isAdmin(email: String) = adminUsers(email.toLowerCase)
+  private def isAuthorized(email: String) =
+    email.toLowerCase.endsWith("@" + authorizedDomain)
+
+  override def generate(context: WebContext,
+                        profile: CommonProfile): CommonProfile = {
+    val userEmail = profile.getEmail
+
+    if (isAuthorized(userEmail)) profile.addRole("user")
+    if (isAdmin(userEmail)) profile.addRole("admin")
+
+    profile.setId(userEmail)
+    profile.clearSensitiveData()
+    profile.setRemembered(true)
+
+    profile
+  }
+}


### PR DESCRIPTION
Basic `EnvDomainAuthorizer` that reads from env var for:
- `AUTHORIZED_DOMAIN`, domain of user email (e.g. `example.com`)
- `ADMIN_USERS`, name part of email to allow as admin (e.g. `admin`, multiple values allowed, delimited by comma)